### PR TITLE
[android-security-13.0.0_r9] Allow sensors list to be empty

### DIFF
--- a/libs/sensor/SensorManager.cpp
+++ b/libs/sensor/SensorManager.cpp
@@ -176,11 +176,8 @@ status_t SensorManager::assertStateLocked() {
 
         mSensors = mSensorServer->getSensorList(mOpPackageName);
         size_t count = mSensors.size();
-        if (count == 0) {
-            ALOGE("Failed to get Sensor list");
-            mSensorServer.clear();
-            return UNKNOWN_ERROR;
-        }
+        // If count is 0, mSensorList will be non-null. This is old
+        // existing behavior and callers expect this.
         mSensorList =
                 static_cast<Sensor const**>(malloc(count * sizeof(Sensor*)));
         LOG_ALWAYS_FATAL_IF(mSensorList == nullptr, "mSensorList NULL");


### PR DESCRIPTION
Test: atest VtsHalSensorManagerV1_0TargetTest
Bug: 278013275
Bug: 269014004
(cherry picked from https://googleplex-android-review.googlesource.com/q/commit:49600b10aa5675d4e7e985203d69f252ead13e45) (cherry picked from https://googleplex-android-review.googlesource.com/q/commit:d9e0d0ad7cb94b2b2d83066685cee45d76381355) Merged-In: I091f57de9570b0ace3a8da76f16fe0e83f0aa624 Change-Id: I091f57de9570b0ace3a8da76f16fe0e83f0aa624