### PR TITLE
include DropBox entries in bugreport zip on user builds

### DIFF
--- a/cmds/dumpstate/dumpstate.cpp
+++ b/cmds/dumpstate/dumpstate.cpp
@@ -1915,11 +1915,10 @@ Dumpstate::RunStatus Dumpstate::DumpstateDefaultAfterCritical() {
     DumpIpTablesAsRoot();
     DumpDynamicPartitionInfo();
     ds.AddDir(OTA_METADATA_DIR, true);
-    if (!PropertiesHelper::IsUserBuild()) {
-        // Include dropbox entry files inside ZIP, but exclude
-        // noisy WTF and StrictMode entries
-        dump_files("", DROPBOX_DIR, skip_wtf_strictmode, _add_file_from_fd);
-    }
+
+    // Include dropbox entry files inside ZIP, but exclude
+    // noisy WTF and StrictMode entries
+    dump_files("", DROPBOX_DIR, skip_wtf_strictmode, _add_file_from_fd);
 
     // Capture any IPSec policies in play. No keys are exposed here.
     RunCommand("IP XFRM POLICY", {"ip", "xfrm", "policy"}, CommandOptions::WithTimeout(10).Build());


### PR DESCRIPTION
DropBox entries contain info about Java and native crashes of apps and system processes, ANRs, low memory conditions, kernel crash logs (last_kmsg), file system check errors etc.