### PR TITLE
enable the new ART pre-reboot dexopt

### DIFF
--- a/cmds/installd/otapreopt_script.sh
+++ b/cmds/installd/otapreopt_script.sh
@@ -20,9 +20,6 @@
 # OTA package, but runs /system/bin/otapreopt_chroot in the (old) active system
 # image. See system/extras/postinst/postinst.sh for some docs.
 
-echo "otapreopt is disabled"
-exit 0
-
 TARGET_SLOT="$1"
 STATUS_FD="$2"
 


### PR DESCRIPTION
Since Android 15, the reverted change disabled the new ART pre-reboot dexopt as well as broken otapreopt.

Part of a changelist:
https://github.com/GrapheneOS/platform_art/pull/25
https://github.com/GrapheneOS/platform_frameworks_base/pull/94