### PR TITLE
gmscompat: remove error string from doDump()

### DIFF
--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -5887,9 +5887,10 @@ status_t SurfaceFlinger::doDump(int fd, const DumpArgs& args, bool asProto) {
     const int uid = ipc->getCallingUid();
 
     if ((uid != AID_SHELL) && !PermissionCache::checkPermission(sDump, pid, uid)) {
-        StringAppendF(&result, "Permission Denial: can't dump SurfaceFlinger from pid=%d, uid=%d\n",
-                      pid, uid);
-        write(fd, result.c_str(), result.size());
+        ALOGD("doDump: callingPid %i, callingUid %i, asProto %i", pid, uid, (int) asProto);
+        for (auto &arg : args) {
+            ALOGD("doDump: arg %s", String8(arg).c_str());
+        }
         return NO_ERROR;
     }
 


### PR DESCRIPTION
GmsCore calls doDump() with "--displays" arg and fails if "Permission Denial..." is returned. It's not clear what's the purpose of that check, but returning nothing makes it pass.