### PR TITLE
fix MTE crashes from Pixel HWC3 service when an external display connects causing soft reboots

### DIFF
--- a/services/surfaceflinger/DisplayHardware/AidlComposerHal.cpp
+++ b/services/surfaceflinger/DisplayHardware/AidlComposerHal.cpp
@@ -291,6 +291,10 @@ AidlComposer::AidlComposer(const std::string& serviceName) {
 
 AidlComposer::~AidlComposer() = default;
 
+bool AidlComposer::isLayerCommandBatchingEnabled() const {
+    return mEnableLayerCommandBatchingFlag;
+}
+
 bool AidlComposer::isSupported(OptionalFeature feature) const {
     switch (feature) {
         case OptionalFeature::RefreshRateSwitching:

--- a/services/surfaceflinger/DisplayHardware/AidlComposerHal.h
+++ b/services/surfaceflinger/DisplayHardware/AidlComposerHal.h
@@ -69,6 +69,8 @@ public:
 
     void registerCallback(HWC2::ComposerCallback& callback) override;
 
+    bool isLayerCommandBatchingEnabled() const override;
+
     // Explicitly flush all pending commands in the command buffer.
     Error executeCommands(Display) override;
 

--- a/services/surfaceflinger/DisplayHardware/ComposerHal.h
+++ b/services/surfaceflinger/DisplayHardware/ComposerHal.h
@@ -121,6 +121,9 @@ public:
 
     virtual void registerCallback(HWC2::ComposerCallback& callback) = 0;
 
+    // Whether layer lifecycle command batching is enabled (HAL capability + flag).
+    virtual bool isLayerCommandBatchingEnabled() const = 0;
+
     // Explicitly flush all pending commands in the command buffer.
     virtual Error executeCommands(Display) = 0;
 

--- a/services/surfaceflinger/DisplayHardware/HWComposer.cpp
+++ b/services/surfaceflinger/DisplayHardware/HWComposer.cpp
@@ -688,6 +688,10 @@ status_t HWComposer::presentAndGetReleaseFences(
     return NO_ERROR;
 }
 
+bool HWComposer::isLayerCommandBatchingEnabled() const {
+    return mComposer->isLayerCommandBatchingEnabled();
+}
+
 status_t HWComposer::executeCommands(HalDisplayId displayId) {
     auto& hwcDisplay = mDisplayData[displayId].hwcDisplay;
     auto error = static_cast<hal::Error>(mComposer->executeCommands(hwcDisplay->getId()));

--- a/services/surfaceflinger/DisplayHardware/HWComposer.h
+++ b/services/surfaceflinger/DisplayHardware/HWComposer.h
@@ -175,6 +175,8 @@ public:
             HalDisplayId,
             std::optional<std::chrono::steady_clock::time_point> earliestPresentTime) = 0;
 
+    virtual bool isLayerCommandBatchingEnabled() const = 0;
+
     virtual status_t executeCommands(HalDisplayId) = 0;
 
     // set power mode
@@ -397,6 +399,8 @@ public:
     status_t presentAndGetReleaseFences(
             HalDisplayId,
             std::optional<std::chrono::steady_clock::time_point> earliestPresentTime) override;
+
+    bool isLayerCommandBatchingEnabled() const override;
 
     status_t executeCommands(HalDisplayId) override;
 

--- a/services/surfaceflinger/DisplayHardware/HidlComposerHal.h
+++ b/services/surfaceflinger/DisplayHardware/HidlComposerHal.h
@@ -174,6 +174,8 @@ public:
 
     void registerCallback(HWC2::ComposerCallback& callback) override;
 
+    bool isLayerCommandBatchingEnabled() const override { return false; }
+
     // Explicitly flush all pending commands in the command buffer.
     Error executeCommands(Display) override;
 

--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -3997,6 +3997,81 @@ bool SurfaceFlinger::configureLocked() {
     }
 
     for (const auto [hwcDisplayId, event] : events) {
+        // Work around a bug in android.hardware.composer.hwc3-service.pixel where
+        // ExynosExternalDisplay::closeExternalDisplay() does not clean up its mIgnoreLayers vector.
+        // When disconnecting an external display, destroy all HWC layers for the external display
+        // before onHotplug() removes the AIDL writer. This ensures that
+        // ExynosDisplay::destroyLayer() gets called in Pixel HWC which cleans both mLayers and
+        // mIgnoreLayers.
+        //
+        // clearOutputLayers() triggers the following destructor chain:
+        //
+        // Output::clearOutputLayers() [compositionengine/impl/Output.h]
+        //   -> vector<unique_ptr<OutputLayer>>::clear()
+        //   -> ~OutputLayer() -> ~OutputLayerCompositionState()
+        //   -> ~Hwc() [impl/OutputLayerCompositionState.h]
+        //   -> ~shared_ptr<HWC2::Layer>() (last owner, weak_ptr in HWC2::Display::mLayers)
+        //   -> HWC2::Layer::~Layer() [HWC2.cpp]
+        //   -> onOwningDisplayDestroyed() [HWC2.cpp]
+        //   -> mDisplay->onLayerDestroyed(mId) -- erases from mLayers
+        //   -> mComposer.destroyLayer(displayId, mId) [AidlComposerHal.cpp]
+        //   -> [batching enabled] queues DESTROY in writer, not sent to HAL yet
+        //
+        // executeCommands() flushes the batched DESTROY commands to the HAL:
+        //
+        // HWComposer::executeCommands() [HWComposer.cpp]
+        //   -> AidlComposer::execute() [AidlComposerHal.cpp]
+        //     -> writer->takePendingCommands() -- drains DESTROY commands from writer
+        //     -> mAidlComposerClient->executeCommands() -- sends to HAL over AIDL
+        //       -> ExynosDisplay::destroyLayer() [hardware/google/graphics/common ExynosDisplay.cpp]
+        //         -> removes layer from mLayers or mIgnoreLayers, deletes it
+        //
+        // Both must happen before onHotplug() calls removeDisplay() which erases the writer via
+        // mWriters.erase(display) [AidlComposerHal.cpp]
+        //
+        // When command batching is enabled, then, without this fix, layers are destroyed too late
+        // by the following existing path due to command batching being enabled:
+        //
+        // onHotplug(Disconnected)
+        //   -> HWComposer::onHotplugDisconnect() [HWComposer.cpp]
+        //     -> mComposer->onHotplugDisconnect()
+        //       -> AidlComposer::removeDisplay() -- mWriters.erase(display) (**)
+        // ... (next transaction commit) ...
+        // processDisplayRemoved() [SurfaceFlinger.cpp]
+        //   -> display->disconnect()
+        //   -> HWComposer::disconnectDisplay() [HWComposer.cpp]
+        //   -> mDisplayData.erase(displayId)
+        //   -> HWC2::Display::~Display() [HWC2.cpp]
+        //   -> for each layer: onOwningDisplayDestroyed():
+        //      -> mComposer.destroyLayer() [AidlComposerHal.cpp]
+        //      -> enters getWriter(display), because mEnableLayerCommandBatchingFlag is true
+        //      -> [batching] getWriter(display) returns null
+        //         due to (**) from onHotplug(Disconnected) removing the writer -> BAD_DISPLAY
+        //      -> command never reaches HAL, layers left in mIgnoreLayers
+        //
+        // If command batching was disabled, processDisplayRemoved() -> HWC2::Display::~Display()
+        // actually gets the Pixel HWC to clear mIgnoreLayers properly, since it makes a
+        // direct mAidlComposerClient->destroyLayer call. That is, with command batching disabled,
+        // this use-after-free bug doesn't occur.
+        if (event == HWComposer::HotplugEvent::Disconnected &&
+                getHwComposer().isLayerCommandBatchingEnabled()) {
+            if (const auto displayIdOpt = getHwComposer().toPhysicalDisplayId(hwcDisplayId)) {
+                if (getHwComposer().getDisplayConnectionType(*displayIdOpt) == ui::DisplayConnectionType::External &&
+                        base::GetProperty("ro.product.manufacturer", "") == "Google") {
+                    // we're in a function called configureLocked, so assume mStateLock is being
+                    // held
+                    if (const auto display = getDisplayDeviceLocked(*displayIdOpt)) {
+                        ALOGI("Clearing output layers for external display %" PRIu64
+                              " before hotplug disconnect to work around stale pointer in"
+                              " mIgnoreLayers in Pixel HWC code",
+                              hwcDisplayId);
+                        display->getCompositionDisplay()->clearOutputLayers();
+                        getHwComposer().executeCommands(*displayIdOpt);
+                    }
+                }
+            }
+        }
+
         auto info = getHwComposer().onHotplug(hwcDisplayId, event);
         if (!info) {
             continue;

--- a/services/surfaceflinger/tests/unittests/SurfaceFlinger_DisplayTransactionCommitTest.cpp
+++ b/services/surfaceflinger/tests/unittests/SurfaceFlinger_DisplayTransactionCommitTest.cpp
@@ -103,7 +103,22 @@ void DisplayTransactionCommitTest::verifyDisplayIsConnected(const sp<IBinder>& d
     ASSERT_TRUE(hasDisplayDevice(displayToken));
     const auto& display = getDisplayDevice(displayToken);
 
-    EXPECT_EQ(static_cast<bool>(Case::Display::SECURE), display.isSecure());
+    // Physical external displays start non-secure when HDCP support is enabled, and only become
+    // secure later after HDCP negotiation succeeds. Pixel devices set debug.sf.hdcp_support=1.
+    // When DisplayModeController::supportsHdcp() is true, DisplayModeController::registerDisplay()
+    // sets external displays to non-secure initially. They become secure later via
+    // SurfaceFlinger::updateHdcpLevels() once HDCP negotiation reports connectedLevel >= HDCP_V1.
+    // Doesn't seem straightforward to mock negotiations here.
+    const auto connectionType = Case::Display::CONNECTION_TYPE::value;
+    const bool hdcpExternalConnection = connectionType &&
+            *connectionType == ui::DisplayConnectionType::External &&
+            mFlinger.mutableDisplayModeController().supportsHdcp();
+    if (hdcpExternalConnection) {
+        EXPECT_EQ(false, display.isSecure());
+    } else {
+        EXPECT_EQ(static_cast<bool>(Case::Display::SECURE), display.isSecure());
+    }
+
     EXPECT_EQ(static_cast<bool>(Case::Display::PRIMARY), display.isPrimary());
 
     std::optional<DisplayDeviceState::Physical> expectedPhysical;

--- a/services/surfaceflinger/tests/unittests/mock/DisplayHardware/MockComposer.h
+++ b/services/surfaceflinger/tests/unittests/mock/DisplayHardware/MockComposer.h
@@ -59,6 +59,7 @@ public:
                  std::vector<aidl::android::hardware::graphics::composer3::Capability>());
     MOCK_METHOD0(dumpDebugInfo, std::string());
     MOCK_METHOD1(registerCallback, void(HWC2::ComposerCallback&));
+    MOCK_METHOD(bool, isLayerCommandBatchingEnabled, (), (const, override));
     MOCK_METHOD1(executeCommands, Error(Display));
     MOCK_METHOD0(getMaxVirtualDisplayCount, uint32_t());
     MOCK_METHOD4(createVirtualDisplay, Error(uint32_t, uint32_t, PixelFormat*, Display*));

--- a/services/surfaceflinger/tests/unittests/mock/DisplayHardware/MockHWComposer.h
+++ b/services/surfaceflinger/tests/unittests/mock/DisplayHardware/MockHWComposer.h
@@ -60,6 +60,7 @@ public:
                 (override));
     MOCK_METHOD(status_t, presentAndGetReleaseFences,
                 (HalDisplayId, std::optional<std::chrono::steady_clock::time_point>), (override));
+    MOCK_METHOD(bool, isLayerCommandBatchingEnabled, (), (const, override));
     MOCK_METHOD(status_t, executeCommands, (HalDisplayId));
     MOCK_METHOD(status_t, setPowerMode, (PhysicalDisplayId, PowerMode), (override));
     MOCK_METHOD(status_t, setColorTransform, (HalDisplayId, const mat4&), (override));


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7512

Work around a bug in Google's Pixel HWC service (android.hardware.composer.hwc3-service.pixel) (or
SurfaceFlinger!) where ExynosExternalDisplay::closeExternalDisplay()
(https://android.googlesource.com/platform/hardware/google/graphics/common/+/refs/heads/main/libhwc2.1/libexternaldisplay/ExynosExternalDisplay.cpp#120)
cleans up fences in mLayers but never erases the mIgnoreLayers vector. Layers moved to mIgnoreLayers
(via ExynosDisplay::checkIgnoreLayers() when plane alpha becomes 0) accumulate as stale pointers
across disconnect/reconnect cycles. On reconnecting an external display, this can cause an MTE crash
via:

- DRM commit fails (ret=-16, EBUSY from drmModeAtomicCommit) in
  ExynosDisplayDrmInterface::deliverWinConfigData()
(https://android.googlesource.com/platform/hardware/google/graphics/common/+/refs/heads/main/libhwc2.1/libdevice/ExynosDisplay.cpp#2764)
  This is not deterministic, so it won't happen on every external display connect.
- ExynosDisplay::deliverWinConfigData() error path calls ExynosDisplay::printDebugInfos()
- printDebugInfos() iterates mIgnoreLayers, calling ExynosLayer::printLayer() on stale pointers
- printLayer() calls VendorGraphicBufferMeta::init() on the freed layer's buffer handle

This leads to the Pixel HWC service crashing. The HWC's init.rc specifies that when HWC restarts, it
should also restart SurfaceFlinger. system_server sees that SurfaceFlinger dies and soft reboots the
device.

This memory bug can also be reproduced on stock OS CP21.260306.017 (Android 17 Beta 3), although
they don't have MTE enabled for the binary, so there's no crashing involved. The bug can instead be
seen from `adb shell dumpsys SurfaceFlinger` with an external display connected (this is needed for
HWC to dump layers for the external display).  Running that dumpsys command periodically after
disconnecting and reconnecting the external display multiple times will show the `dump ignore
layers` growing for the external display between each dump.

This bug cannot be reproduced on stock CP1A.260305.018 (16 QPR3) because of a logic bug in
SurfaceFlinger which makes command batching always disabled (see previous commit for details).
Command batching is required to reproduce this stale mIgnoreLayers bug.



With enable_layer_command_batching disabled, SF's layer destruction during disconnect acts as a
second line of defense against the mIgnoreLayers bug, and this is probably unintentional(?). When
HWC2::Display::~Display() runs during SurfaceFlinger::processDisplayRemoved(), it destroys all its
HWC2::Layer objects, and AidlComposer::destroyLayer() makes direct
mAidlComposerClient->destroyLayer() AIDL calls that reach the HAL even after hotplug disconnect (the
AIDL composer client and HAL display object still exist). ExynosDisplay::destroyLayer() then removes
each layer from both mLayers and mIgnoreLayers. So even though
ExynosExternalDisplay::closeExternalDisplay() never erases mIgnoreLayers, the layers still get
cleaned up indirectly through SF's destruction path.

However, when the enable_layer_command_batching flag is enabled (the current default since bp1a,
inherited through bp4a) and the HWC service reports Capability::LAYER_LIFECYCLE_BATCH_COMMAND, this
second line of defense breaks. On Pixels, both of these are true.

- AidlComposer::destroyLayer() batches DESTROY commands in a per-display ComposerClientWriter rather
  than making direct AIDL calls.
- On disconnect,AidlComposer::onHotplugDisconnect() calls AidlComposer::removeDisplay() which erases
  the writer via mWriters.erase(display).
- HWC2::Display::~Display() runs later during SurfaceFlinger::processDisplayRemoved(), and its
  AidlComposer::destroyLayer() calls find no writer and return BAD_DISPLAY.
- The destroyLayer commands never reach the HAL, leaving layers in mIgnoreLayers as stale pointers,
  because Pixel HWC didn't seem to clean them up themselves.

It's unknown at this point if this is a bug with command batching in SurfaceFlinger (i.e., are
vendors expecting SurfaceFlinger to clear the layers for them on external display disconnect) or an
isolated issue with libexynosdisplay.so. libexynosdisplay.so seems to be buggy, because disconnect
should not leave stale layer pointers behind. But SurfaceFlinger batching also changes the effective
contract on disconnect by preventing explicit layer-destroy commands from reaching the HAL at a
point where older/non-batched behavior did allow that cleanup.

Fix this use-after-free / stale mIgnoreLayers issue by explicitly destroying all layers before the
writer is removed, ensuring ExynosDisplay::destroyLayer() in the HWC service removes each layer from
both mLayers and mIgnoreLayers. These layers are meant to be destroyed on hotplug disconnect anyway;
the destruction sequence is outlined with more detail in the code comments. The fix simply moves
destruction earlier in the disconnect sequence so the batched commands are flushed while the writer
still exists. We only use our fix for external displays on Google devices with command batching
enabled.

The libexynosdisplay.so source that the HWC service uses is in a common source set
(https://android.googlesource.com/platform/hardware/google/graphics/common) compiled into all
SoC-specific builds. This source is no longer updated by Google, so the fix must be done in
SurfaceFlinger.

In SurfaceFlinger::configureLocked(), before HWComposer::onHotplug() removes the writer:

1. CompositionDisplay::clearOutputLayers() releases all OutputLayer shared_ptrs, triggering the
   destructor chain through HWC2::Layer::~Layer() -> HWC2::Layer::onOwningDisplayDestroyed() ->
   AidlComposer::destroyLayer(), which queues batched DESTROY commands in the writer
2. HWComposer::executeCommands() flushes the batched commands to the HAL, where
   ExynosDisplay::destroyLayer() removes each layer from mLayers or mIgnoreLayers and deletes it

Note: ExynosExternalDisplay::closeExternalDisplay() sets mPlugState to false on Pixel HWC's DRM
event thread asynchronously before SF receives the hotplug callback. By the time the fix or any SF
code runs, mPlugState is already false. ExynosDisplay::destroyLayer() still performs the full
cleanup (remove from mLayers/mIgnoreLayers, delete layer) unconditionally, then checks mPlugState
and returns HWC2_ERROR_BAD_DISPLAY:

```c++
  // libhwc2.1/libdevice/ExynosDisplay.cpp
  // https://android.googlesource.com/platform/hardware/google/graphics/common/+/refs/heads/main/libhwc2.1/libdevice/ExynosDisplay.cpp#1179
  int32_t ExynosDisplay::destroyLayer(hwc2_layer_t outLayer) {
      // ...
      if (mLayers.remove(layer) < 0) {
          auto it = std::find(mIgnoreLayers.begin(), mIgnoreLayers.end(), layer);
          if (it != end) mIgnoreLayers.erase(it);
      }
      // ...
      delete layer;
      if (mPlugState == false) {
          DISPLAY_LOGI("destroyLayer is done. But display is already disconnected");
          return HWC2_ERROR_BAD_DISPLAY;  // misleading: cleanup already succeeded
      }
      return HWC2_ERROR_NONE;
  }
```

HWC2_ERROR_BAD_DISPLAY (= 2) propagates up as "HalImpl: destroyLayer failed with error: 2" (logged
by HalImpl::destroyLayer() in the HWC service) and "command '...' generated error 2" (logged by
AidlComposer::executeCommands() in SF when processing command results). Both warnings are cosmetic;
the layer has already been fully removed and freed.

An alternative approach would be to add a fallback to a direct AIDL call in
AidlComposer::destroyLayer() when the writer is missing (the else branch at
https://github.com/GrapheneOS/platform_frameworks_native/blob/2026032000/services/surfaceflinger/DisplayHardware/AidlComposerHal.cpp#L475-L477
currently returns BAD_DISPLAY). This would make the batching path resilient to writer removal
without requiring changes in SurfaceFlinger::configureLocked(). However, this would probably be too
broad for a downstream change, and AidlComposer has no display type information to gate the fallback
to external displays only (other than perhaps hardcoding display id of 256, but this ID comes from
Pixel HWC3 itself).

Test: MTE crashes no longer happen after multiple external display connect and disconnect cycles.
`adb shell dumpsys SurfaceFlinger` (with external display connected) after various disconnect and
reconnect repeats doesn't show a growing list of ignore layers for the external display.
Test: atest surfaceflinger_end2end_tests libsurfaceflinger_unittest libcompositionengine_test
Test: atest SurfaceFlinger_test